### PR TITLE
feat(backend): Material & Product class + API

### DIFF
--- a/backend/ERPNumber1/ERPNumber1/Controllers/MaterialsController.cs
+++ b/backend/ERPNumber1/ERPNumber1/Controllers/MaterialsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ERPNumber1.Data;
+using ERPNumber1.Models;
+
+namespace ERPNumber1.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MaterialsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public MaterialsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Materials
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Material>>> GetMaterials()
+        {
+            return await _context.Materials.ToListAsync();
+        }
+
+        // GET: api/Materials/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Material>> GetMaterial(int id)
+        {
+            var material = await _context.Materials.FindAsync(id);
+
+            if (material == null)
+            {
+                return NotFound();
+            }
+
+            return material;
+        }
+
+        // PUT: api/Materials/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutMaterial(int id, Material material)
+        {
+            if (id != material.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(material).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!MaterialExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Materials
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Material>> PostMaterial(Material material)
+        {
+            _context.Materials.Add(material);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetMaterial", new { id = material.Id }, material);
+        }
+
+        // DELETE: api/Materials/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteMaterial(int id)
+        {
+            var material = await _context.Materials.FindAsync(id);
+            if (material == null)
+            {
+                return NotFound();
+            }
+
+            _context.Materials.Remove(material);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool MaterialExists(int id)
+        {
+            return _context.Materials.Any(e => e.Id == id);
+        }
+    }
+}

--- a/backend/ERPNumber1/ERPNumber1/Controllers/ProductsController.cs
+++ b/backend/ERPNumber1/ERPNumber1/Controllers/ProductsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ERPNumber1.Data;
+using ERPNumber1.Models;
+
+namespace ERPNumber1.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ProductsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public ProductsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Products
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Product>>> GetProducts()
+        {
+            return await _context.Products.ToListAsync();
+        }
+
+        // GET: api/Products/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Product>> GetProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            return product;
+        }
+
+        // PUT: api/Products/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutProduct(int id, Product product)
+        {
+            if (id != product.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(product).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ProductExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Products
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Product>> PostProduct(Product product)
+        {
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetProduct", new { id = product.Id }, product);
+        }
+
+        // DELETE: api/Products/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            _context.Products.Remove(product);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool ProductExists(int id)
+        {
+            return _context.Products.Any(e => e.Id == id);
+        }
+    }
+}

--- a/backend/ERPNumber1/ERPNumber1/Data/AppDbContext.cs
+++ b/backend/ERPNumber1/ERPNumber1/Data/AppDbContext.cs
@@ -11,6 +11,11 @@ namespace ERPNumber1.Data
 
         public DbSet<Simulation> Simulations { get; set; }
         public DbSet<Round> Rounds { get; set; }
+        public DbSet<ERPNumber1.Models.User> User { get; set; } = default!;
+
+        // Added DbSet for Product and Material
+        public DbSet<Product> Products { get; set; }
+        public DbSet<Material> Materials { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -18,7 +23,13 @@ namespace ERPNumber1.Data
                 .HasMany(s => s.Rounds)
                 .WithOne(r => r.Simulation)
                 .HasForeignKey(r => r.SimulationId);
+
+            // Configure Product-Material relationship
+            modelBuilder.Entity<Product>()
+                .HasMany(p => p.materials)
+                .WithOne(m => m.product)
+                .HasForeignKey(m => m.productId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
-        public DbSet<ERPNumber1.Models.User> User { get; set; } = default!;
     }
 }

--- a/backend/ERPNumber1/ERPNumber1/ERPNumber1.csproj.user
+++ b/backend/ERPNumber1/ERPNumber1/ERPNumber1.csproj.user
@@ -11,6 +11,8 @@
     <WebStackScaffolding_LayoutPageFile />
     <WebStackScaffolding_DbContextTypeFullName>ERPNumber1.Data.AppDbContext</WebStackScaffolding_DbContextTypeFullName>
     <WebStackScaffolding_IsAsyncSelected>False</WebStackScaffolding_IsAsyncSelected>
+    <Controller_SelectedScaffolderID>ApiControllerWithContextScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/backend/ERPNumber1/ERPNumber1/Models/Material.cs
+++ b/backend/ERPNumber1/ERPNumber1/Models/Material.cs
@@ -1,0 +1,26 @@
+﻿namespace ERPNumber1.Models
+{
+    public class Material
+    {
+        public int Id { get; set; }
+        public int productId { get; set; }
+        public string name { get; set; }
+        public float cost { get; set; }
+        public int quantity { get; set; }
+        public Product product { get; set; }
+
+        public Material()
+        {
+        }
+
+        public Material(int id, int productId, string name, float cost, int quantity, Product product)
+        {
+            Id = id;
+            this.productId = productId;
+            this.name = name;
+            this.cost = cost;
+            this.quantity = quantity;
+            this.product = product;
+        }
+    }
+}

--- a/backend/ERPNumber1/ERPNumber1/Models/Product.cs
+++ b/backend/ERPNumber1/ERPNumber1/Models/Product.cs
@@ -1,0 +1,22 @@
+﻿namespace ERPNumber1.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public int orderId { get; set; }
+        public char type { get; set; }
+        public List<Material> materials { get; set; } = new List<Material>();
+
+        public Product()
+        {
+        }
+
+        public Product(int id, int orderId, char type, List<Material> materials)
+        {
+            Id = id;
+            this.orderId = orderId;
+            this.type = type;
+            this.materials = materials;
+        }
+    }
+}


### PR DESCRIPTION
✨ Description

This PR introduces the following changes:
•	Adds Product and Material entities to the Entity Framework Core context (AppDbContext).
•	Configures a one-to-many relationship between Product and Material (a product can have many materials).
•	Adds ProductsController and MaterialsController to enable CRUD operations for products and materials via the API.

🕵 Background

These changes are necessary to:
•	Allow the application to persist and manage products and their associated materials in the database.
•	Provide API endpoints for creating, reading, updating, and deleting products and materials.
•	Ensure the relationship between products and materials is enforced and accessible through the API.

📝 Resources

•	EF Core Relationships Documentation
•	DbContext and DbSet in EF Core
•	ASP.NET Core Web API Controllers
•	Cascade Delete Behavior