### PR TITLE
fix(infra): nginx not able to use websockets

### DIFF
--- a/backend/ERPNumber1/ERPNumber1/Program.cs
+++ b/backend/ERPNumber1/ERPNumber1/Program.cs
@@ -68,10 +68,28 @@ builder.Services.AddAuthentication(options =>
         ValidIssuer = builder.Configuration["JWT:Issuer"],
         ValidateAudience = true,
         ValidAudience = builder.Configuration["JWT:Audience"],
-        ValidateIssuerSigningKey = true,
-        IssuerSigningKey = new SymmetricSecurityKey(
-            System.Text.Encoding.UTF8.GetBytes(builder.Configuration["JWT:SigningKey"])
+        ValidateIssuerSigningKey = true,        IssuerSigningKey = new SymmetricSecurityKey(
+            System.Text.Encoding.UTF8.GetBytes(builder.Configuration["JWT:SigningKey"] ?? "")
         )
+    };
+
+    // Add support for SignalR authentication
+    options.Events = new JwtBearerEvents
+    {
+        OnMessageReceived = context =>
+        {
+            var accessToken = context.Request.Query["access_token"];
+
+            // If the request is for our SignalR hub...
+            var path = context.HttpContext.Request.Path;
+            if (!string.IsNullOrEmpty(accessToken) &&
+                (path.StartsWithSegments("/simulationHub")))
+            {
+                // Read the token out of the query string
+                context.Token = accessToken;
+            }
+            return Task.CompletedTask;
+        }
     };
 });
 

--- a/docs/infra/signalr-websocket-fix.md
+++ b/docs/infra/signalr-websocket-fix.md
@@ -1,0 +1,119 @@
+# SignalR WebSocket Proxy Fix
+
+## Problem
+SignalR was working locally but failing when running through the nginx proxy in the Docker environment. This was due to missing WebSocket support in the nginx configuration.
+
+## Changes Made
+
+### 1. Updated nginx configuration (`proxy/nginx.conf.template`)
+- Added WebSocket upgrade mapping for proper connection handling
+- Added specific WebSocket headers for SignalR hub endpoint
+- Added optimizations for long-running connections
+- Disabled proxy buffering for real-time communication
+
+### 2. Enhanced JWT Authentication (`backend/ERPNumber1/ERPNumber1/Program.cs`)
+- Added support for JWT token authentication via query string for WebSocket connections
+- Added specific handler for SignalR hub authentication
+- Fixed null reference warning for JWT signing key
+
+## Key Configuration Details
+
+### Nginx WebSocket Support
+```nginx
+# WebSocket upgrade mapping
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+# SignalR-specific location block
+location /simulationHub/ {
+  # Standard proxy headers
+  proxy_pass http://$backend_host;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  
+  # WebSocket support
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $connection_upgrade;
+  proxy_cache_bypass $http_upgrade;
+  proxy_read_timeout 86400;
+  proxy_send_timeout 86400;
+  proxy_connect_timeout 60s;
+  
+  # SignalR optimizations
+  proxy_buffering off;
+  proxy_redirect off;
+}
+```
+
+### JWT for WebSocket Authentication
+```csharp
+options.Events = new JwtBearerEvents
+{
+    OnMessageReceived = context =>
+    {
+        var accessToken = context.Request.Query["access_token"];
+        var path = context.HttpContext.Request.Path;
+        
+        if (!string.IsNullOrEmpty(accessToken) &&
+            path.StartsWithSegments("/simulationHub"))
+        {
+            context.Token = accessToken;
+        }
+        return Task.CompletedTask;
+    }
+};
+```
+
+## Testing the Fix
+
+1. **Rebuild the containers:**
+   ```bash
+   docker-compose down
+   docker-compose build --no-cache proxy api
+   docker-compose up
+   ```
+
+2. **Test SignalR connection:**
+   - Open browser developer tools (Network tab)
+   - Look for WebSocket connections to `/simulationHub`
+   - Connection should show as "101 Switching Protocols"
+
+3. **Test real-time functionality:**
+   - Start a simulation from the frontend
+   - Multiple browser tabs should receive real-time updates
+   - Check console logs for SignalR connection messages
+
+## Expected Behavior
+
+- ✅ SignalR should successfully establish WebSocket connection through nginx proxy
+- ✅ Real-time simulation updates should work across all connected clients
+- ✅ Connection should gracefully fallback to Server-Sent Events or Long Polling if WebSocket fails
+- ✅ JWT authentication should work for WebSocket connections
+
+## Troubleshooting
+
+If SignalR still doesn't work:
+
+1. **Check nginx logs:**
+   ```bash
+   docker logs nginx_proxy
+   ```
+
+2. **Check backend logs:**
+   ```bash
+   docker logs backend_app
+   ```
+
+3. **Verify browser console:**
+   - Look for SignalR connection errors
+   - Check for 401 authentication errors
+   - Monitor network traffic for failed WebSocket upgrades
+
+4. **Test direct backend connection:**
+   - Temporarily connect frontend directly to backend (port 8080)
+   - If it works directly but not through proxy, the issue is nginx-related

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -6,6 +6,12 @@ events {
 
 http {
   resolver 127.0.0.11 valid=30s;  # Docker embedded DNS server
+  
+  # WebSocket upgrade mapping for SignalR
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+  }
  
   server {
     listen 80 default_server;
@@ -27,6 +33,19 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      
+      # WebSocket support for SignalR
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_cache_bypass $http_upgrade;
+      proxy_read_timeout 86400;
+      proxy_send_timeout 86400;
+      proxy_connect_timeout 60s;
+      
+      # Additional SignalR optimizations
+      proxy_buffering off;
+      proxy_redirect off;
     }
 
     location / {


### PR DESCRIPTION
## ✨ Description
<!-- Explain what happens in this PR -->

Fixes SignalR WebSocket connections failing through nginx proxy. Adds WebSocket support to nginx configuration and enhances JWT authentication for SignalR hub connections.

**Changes:**
- ✅ Added WebSocket upgrade headers to nginx proxy configuration
- ✅ Enhanced JWT authentication to support query string tokens for WebSocket connections
- ✅ Added SignalR-specific proxy optimizations (timeouts, buffering)

## 🕵 Background
<!-- Explain why this change is being made -->

SignalR worked locally but failed in Docker with nginx proxy due to:
- Missing WebSocket upgrade support in nginx
- JWT tokens can't use Authorization headers in WebSocket connections
- Default proxy buffering interfering with real-time communication

Without this fix: no real-time simulation updates, connection failures, poor user experience.

## 📝 Resources
- See `docs/infra/signalr-websocket-fix.md` for full details